### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 9.0.1.
 
+# Installing
+
+Run `npm ci` to install all locale packages, then `npm install -g @angular/cli` to provide the `ng` command line tool used elsewhere.
+
 ## Development server
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.


### PR DESCRIPTION
This just adds some instructions for people coming from other frameworks (and the little-known `npm ci` command) :-)