### PR TITLE
Added support for animated assets (sprite sheets)

### DIFF
--- a/src/app/core/map/views/area-effect-view.ts
+++ b/src/app/core/map/views/area-effect-view.ts
@@ -17,7 +17,7 @@ export class AreaEffectView extends View {
     grid: Grid;
 
     assetTexture: PIXI.Texture;
-    assetSprite: PIXI.Sprite;
+    assetSprite: PIXI.AnimatedSprite;
 
     shapeGraphics: PIXI.Graphics;
     handlesGraphics: PIXI.Graphics;
@@ -177,9 +177,24 @@ export class AreaEffectView extends View {
         }
 
         // sprite
-        if (this.assetTexture != null) {
-            let sprite = new PIXI.Sprite(this.assetTexture);
-            
+	if (this.assetTexture != null) {
+            let frames = [ ];
+            if (this.areaEffect.asset.type == "spriteSheet") {
+                for(let x=0,y=0,framecount=0; x < this.assetTexture.baseTexture.width && y < this.assetTexture.baseTexture.height;framecount++) {
+                    let rect = new PIXI.Rectangle(x,y,this.areaEffect.asset.frameWidth,this.areaEffect.asset.frameHeight);
+                    let frame = new PIXI.Texture(this.assetTexture.baseTexture,rect);
+                    frames.push ( frame );
+                    x += this.areaEffect.asset.frameWidth;
+                    if (x>=this.assetTexture.baseTexture.width) {
+                        x = 0;
+                        y += this.areaEffect.asset.frameHeight;
+                    }
+                }
+	    } else {
+                frames.push(this.assetTexture);
+            }
+            let sprite = new PIXI.AnimatedSprite(frames);
+ 
             this.assetSprite = this.addChild(sprite);
 
             switch (this.areaEffect.shape) {
@@ -205,7 +220,9 @@ export class AreaEffectView extends View {
                     sprite.height = this.areaEffect.width;
                     sprite.rotation = this.areaEffect.angle;
                     break;
-            }
+	    }
+	    sprite.animationSpeed = .25;
+            sprite.play();
         }
 
         return this;

--- a/src/app/core/map/views/aura-view.ts
+++ b/src/app/core/map/views/aura-view.ts
@@ -9,7 +9,7 @@ export class AuraView extends View {
     grid: Grid;
 
     assetTexture: PIXI.Texture;
-    assetSprite: PIXI.Sprite;
+    assetSprite: PIXI.AnimatedSprite;
 
     shapeGraphics: PIXI.Graphics;
 
@@ -58,14 +58,31 @@ export class AuraView extends View {
         }
 
         // sprite
-        if (this.assetTexture != null) {
-            let sprite = new PIXI.Sprite(this.assetTexture);
+	if (this.assetTexture != null) {
+            let frames = [ ];
+            if (this.aura.asset.type == "spriteSheet") {
+                for(let x=0,y=0,framecount=0; x < this.assetTexture.baseTexture.width && y < this.assetTexture.baseTexture.height;framecount++) {
+                    let rect = new PIXI.Rectangle(x,y,this.aura.asset.frameWidth,this.aura.asset.frameHeight);
+                    let frame = new PIXI.Texture(this.assetTexture.baseTexture,rect);
+                    frames.push ( frame );
+                    x += this.aura.asset.frameWidth;
+                    if (x>=this.assetTexture.baseTexture.width) {
+                        x = 0;
+                        y += this.aura.asset.frameHeight;
+                    }
+                }
+	    } else {
+                frames.push(this.assetTexture);
+            }
+            let sprite = new PIXI.AnimatedSprite(frames);
             
             this.assetSprite = this.addChild(sprite);
             sprite.anchor.set(0.5, 0.5);
             sprite.position.set(-this.w / 2, -this.h / 2)
             sprite.width = this.w;
-            sprite.height = this.h;
+	    sprite.height = this.h;
+	    sprite.animationSpeed = .25;
+            sprite.play();
         }
 
         return this;

--- a/src/app/core/map/views/tile-view.ts
+++ b/src/app/core/map/views/tile-view.ts
@@ -12,7 +12,7 @@ export class TileView extends View {
     grid: Grid;
 
     assetTexture: PIXI.Texture;
-    assetSprite: PIXI.Sprite;
+    assetSprite: PIXI.AnimatedSprite;
 
     mapLayer: MapLayer = MapLayer.object;
 
@@ -40,11 +40,28 @@ export class TileView extends View {
 
         // sprite
         if (this.assetTexture != null) {
-            let sprite = new PIXI.Sprite(this.assetTexture);
+            let frames = [ ];
+            if (this.tile.asset.type == "spriteSheet") {
+                for(let x=0,y=0,framecount=0; x < this.assetTexture.baseTexture.width && y < this.assetTexture.baseTexture.height;framecount++) {
+                    let rect = new PIXI.Rectangle(x,y,this.tile.asset.frameWidth,this.tile.asset.frameHeight);
+                    let frame = new PIXI.Texture(this.assetTexture.baseTexture,rect);
+                    frames.push ( frame );
+                    x += this.tile.asset.frameWidth;
+                    if (x>=this.assetTexture.baseTexture.width) {
+                        x = 0;
+                        y += this.tile.asset.frameHeight;
+                    }
+                }
+	    } else {
+                frames.push(this.assetTexture);
+            }
+            let sprite = new PIXI.AnimatedSprite(frames);
             sprite.anchor.set(0.5, 0.5);
             sprite.width = this.tile.width;
             sprite.height = this.tile.height;
             sprite.angle = this.tile.rotation;
+            sprite.animationSpeed = .25;
+            sprite.play();
             this.assetSprite = this.addChild(sprite);
         }
 

--- a/src/app/shared/models/asset.ts
+++ b/src/app/shared/models/asset.ts
@@ -3,4 +3,6 @@ export class Asset {
     name: string;
     type: string;
     resource: string;
+    frameWidth: number;
+    frameHeight: number;
 }


### PR DESCRIPTION
I was able to add support for animated assets. Currently, I use a fixed animation speed, because I’m not really sure how I am supposed to convert duration into a speed float value, if there is even a logical way to translate it.