### PR TITLE
Added support for spritesheet duration

### DIFF
--- a/src/app/core/map/views/area-effect-view.ts
+++ b/src/app/core/map/views/area-effect-view.ts
@@ -221,8 +221,13 @@ export class AreaEffectView extends View {
                     sprite.rotation = this.areaEffect.angle;
                     break;
 	    }
-	    sprite.animationSpeed = .25;
-            sprite.play();
+	    if (frames.length > 1) {
+              if (this.areaEffect.asset.duration === undefined) {
+                this.areaEffect.asset.duration = 1.0;
+              }
+	      sprite.animationSpeed = frames.length/this.areaEffect.asset.duration/60.00;
+	      sprite.play();
+            }
         }
 
         return this;

--- a/src/app/core/map/views/aura-view.ts
+++ b/src/app/core/map/views/aura-view.ts
@@ -81,8 +81,13 @@ export class AuraView extends View {
             sprite.position.set(-this.w / 2, -this.h / 2)
             sprite.width = this.w;
 	    sprite.height = this.h;
-	    sprite.animationSpeed = .25;
-            sprite.play();
+            if (frames.length > 1) {
+              if (this.aura.asset.duration === undefined) {
+                this.aura.asset.duration = 1.0;
+              }
+	      sprite.animationSpeed = frames.length/this.aura.asset.duration/60.00;
+	      sprite.play();
+            }
         }
 
         return this;

--- a/src/app/core/map/views/tile-view.ts
+++ b/src/app/core/map/views/tile-view.ts
@@ -40,8 +40,8 @@ export class TileView extends View {
 
         // sprite
         if (this.assetTexture != null) {
-            let frames = [ ];
-            if (this.tile.asset.type == "spriteSheet") {
+	     let frames = [ ];
+	     if (this.tile.asset.type == "spriteSheet") {
                 for(let x=0,y=0,framecount=0; x < this.assetTexture.baseTexture.width && y < this.assetTexture.baseTexture.height;framecount++) {
                     let rect = new PIXI.Rectangle(x,y,this.tile.asset.frameWidth,this.tile.asset.frameHeight);
                     let frame = new PIXI.Texture(this.assetTexture.baseTexture,rect);
@@ -50,8 +50,8 @@ export class TileView extends View {
                     if (x>=this.assetTexture.baseTexture.width) {
                         x = 0;
                         y += this.tile.asset.frameHeight;
-                    }
-                }
+		    }
+		}
 	    } else {
                 frames.push(this.assetTexture);
             }
@@ -59,9 +59,14 @@ export class TileView extends View {
             sprite.anchor.set(0.5, 0.5);
             sprite.width = this.tile.width;
             sprite.height = this.tile.height;
-            sprite.angle = this.tile.rotation;
-            sprite.animationSpeed = .25;
-            sprite.play();
+	    sprite.angle = this.tile.rotation;
+	    if (frames.length > 1) {
+              if (this.tile.asset.duration === undefined) {
+                this.tile.asset.duration = 1.0;
+              }
+	      sprite.animationSpeed = frames.length/this.tile.asset.duration/60.00;
+	      sprite.play();
+            }
             this.assetSprite = this.addChild(sprite);
         }
 

--- a/src/app/shared/models/asset.ts
+++ b/src/app/shared/models/asset.ts
@@ -5,4 +5,5 @@ export class Asset {
     resource: string;
     frameWidth: number;
     frameHeight: number;
+    duration: number;
 }


### PR DESCRIPTION
I figured out that the default animation speed is 60fps, so all I had to do was calculate the proper multiplier to adjust the FPS to match the duration set in EncounterPlus.
Also, I stopped playing the animation if there’s only 1 frame (basically for static images) because that just seems like a waste of cpu.