### PR TITLE
Fixes for ssl and creature auras

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -436,7 +436,7 @@ export class AppComponent implements OnInit, AfterViewInit {
                 localStorage.setItem("lastSuccessfullHost", this.dataService.remoteHost);
 
                 this.toastService.clear();
-                this.toastService.showSuccess("Websocket connected");
+                this.toastService.showSuccess("Connected to EncounterPlus host");
                 this.getData();
 
                 // update color
@@ -446,7 +446,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 
             } else {
                 console.log("Websocket disconnected");
-                this.toastService.showError("Websocket disconnected", false);
+                this.toastService.showError("Could not connect to EncounterPlus host", false);
             }
         });
     }

--- a/src/app/core/creature/creature.component.ts
+++ b/src/app/core/creature/creature.component.ts
@@ -13,7 +13,7 @@ export class CreatureComponent implements OnInit {
   public creature: Creature;
 
   get image(): string {
-    return this.creature.image ? `http://${this.dataService.remoteHost}${this.creature.image}` : "/assets/img/creature.png"
+    return this.creature.image ? `${this.dataService.protocol}//${this.dataService.remoteHost}${this.creature.image}` : "/assets/img/creature.png"
   }
 
   get name(): string {

--- a/src/app/core/image-handout/image-handout.component.ts
+++ b/src/app/core/image-handout/image-handout.component.ts
@@ -17,7 +17,7 @@ export class ImageHandoutComponent implements OnInit {
     if (this.screen.overlayImage && this.screen.overlayImage.startsWith("http")) {
       return this.screen.overlayImage;
     } else {
-      return `http://${this.dataService.remoteHost}${this.screen.overlayImage}`;
+      return `${this.dataService.protocol}//${this.dataService.remoteHost}${this.screen.overlayImage}`;
     }
   }
 

--- a/src/app/core/initiative-list/initiative-list.component.ts
+++ b/src/app/core/initiative-list/initiative-list.component.ts
@@ -25,7 +25,7 @@ export class InitiativeListComponent implements OnInit, OnDestroy, AfterViewChec
   get images(): Array<IAlbum> {
     const images: Array<IAlbum> = [];
     for (const creature of this.activeCreatures) {
-      images.push({ src: `http://${this.dataService.remoteHost}${creature.image}`, caption: null, thumb: null });
+      images.push({ src: `${this.dataService.protocol}//${this.dataService.remoteHost}${creature.image}`, caption: null, thumb: null });
     }
     return images;
   }

--- a/src/app/core/map/map-container.ts
+++ b/src/app/core/map/map-container.ts
@@ -195,7 +195,7 @@ export class MapContainer extends Layer {
         await this.monstersLayer.draw();
         
         await this.playersLayer.draw();
-        this.aurasLayer.tokens = this.playersLayer.views;
+        this.aurasLayer.tokens = [...this.playersLayer.views,...this.monstersLayer.views];
         this.aurasLayer.draw();
         await this.drawTiles();
 

--- a/src/app/shared/models/app-state.ts
+++ b/src/app/shared/models/app-state.ts
@@ -17,7 +17,7 @@ export class AppState {
 
     get mapCreatures(): Array<Creature> {
         return this.game.creatures.filter( creature => {
-            return creature.mapId == this.map.id
+	    return (creature.mapId == undefined || creature.mapId == this.map.id)
         });
     }
 


### PR DESCRIPTION
The handouts and initiative list still specified `http:` directly, instead of automatically determining the protocol.

Auras were not being displayed on creatures because only the players layer was being rendered.