### PR TITLE
Better handling of partial grid squares at edges of map

### DIFF
--- a/src/app/core/map/layers/grid-layer.ts
+++ b/src/app/core/map/layers/grid-layer.ts
@@ -60,21 +60,21 @@ export class GridLayer extends Layer {
 
     async drawGrid() {
         
-        let width = this.w * this.grid.scale + this.grid.size/2;
-        let height = this.h * this.grid.scale + this.grid.size/2;
+        let width = this.w * this.grid.scale;
+        let height = this.h * this.grid.scale;
 
         // columns
-        let cols = Math.floor(width / this.grid.size);
+        let cols = Math.floor((width + this.grid.size*.9)/ this.grid.size);
         for (let i = 0; i < cols; i++) {
             let x = (i * this.grid.size) + this.grid.offsetX;
-            this.addChild(this._drawLine([x, 0, x, height], PIXI.utils.string2hex(this.grid.color), 0.8));
+            if (x<=width) this.addChild(this._drawLine([x, 0, x, height], PIXI.utils.string2hex(this.grid.color), 0.8));
         }
 
         // rows
-        let rows = Math.ceil(height / this.grid.size);
+        let rows = Math.ceil((height + this.grid.size*.9)/ this.grid.size);
         for (let i = 0; i < rows; i++) {
             let y = (i * this.grid.size) + this.grid.offsetY;
-            this.addChild(this._drawLine([0, y, width, y], PIXI.utils.string2hex(this.grid.color), 0.8));
+            if (y<=height) this.addChild(this._drawLine([0, y, width, y], PIXI.utils.string2hex(this.grid.color), 0.8));
         }
 
         return this;
@@ -90,7 +90,7 @@ export class GridLayer extends Layer {
 
         if (this.highlightPath.length > 0) {
             await this.drawHighlight();
-        }       
+        }
 
         return this;
     }


### PR DESCRIPTION
The previous method was causing the grid lines to extend beyond the map. This should constrain them properly, but still draw the lines for partial squares on the edges.