### PR TITLE
Added keyboard and gamepad controls

### DIFF
--- a/src/app/core/map/views/token-view.ts
+++ b/src/app/core/map/views/token-view.ts
@@ -52,6 +52,7 @@ export class TokenView extends View {
 
     data: PIXI.InteractionData
     dragging: boolean = false
+    kbMovement: boolean = false
 
     selected: boolean = false
     turned: boolean = false

--- a/src/app/shared/models/wsevent.ts
+++ b/src/app/shared/models/wsevent.ts
@@ -38,10 +38,12 @@ export enum WSEventName {
     trackedObjectCreated = "trackedObjectCreated",
     trackedObjectUpdated = "trackedObjectUpdated",
     trackedObjectDeleted = "trackedObjectDeleted",
-    trackedObjectsUpdated = "trackedObjectsUpdated"
+    trackedObjectsUpdated = "trackedObjectsUpdated",
+    updateModel = "updateModel"
 }
 
 export interface WSEvent {
     name: WSEventName;
+    model?: string;
     data: any;
 }


### PR DESCRIPTION
This adds keyboard and gamepad controls:
Keyboard:
```
-/=  -  Zoom In/Out viewport
Arrows - Move selected token
Shift+Left/Right - Rotate token
t - center on selected token
Esc - reset token path
```
Gamepad
```
L1/R1  -  Zoom In/Out viewport
R-Joystick - Pan viewport
D-Pad/L-Joystick - Move selected token
L2/R2 - Rotate token
X - center on selected token
Y - reset token path
```
