### PR TITLE
Check for secure context before loading gamepads

### DIFF
--- a/src/app/core/map/map.component.ts
+++ b/src/app/core/map/map.component.ts
@@ -191,7 +191,7 @@ export class MapComponent implements OnInit, OnChanges {
                 this.dataService.send({name: WSEventName.updateModel, model: "token", data: {id: token.token.id, path: []}})
         }
         // Gamepad Controls
-        let gamePads = navigator.getGamepads();
+        let gamePads = (window.isSecureContext)? navigator.getGamepads():null;
         if (gamePads&&gamePads[0]) {
             let gp = gamePads[0];
             if (this.gpTS === undefined) {


### PR DESCRIPTION
This will fix web client crashes on Firefox, and limit gamepads to secure contexts as required by the API